### PR TITLE
Routing demonstration has been added.

### DIFF
--- a/learn-hyper/Cargo.toml
+++ b/learn-hyper/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["George T. C. Lai <tsungchih.hd@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+futures = "0.1"
 hyper = "0.12"
 log = "0.4"
 pretty_env_logger = "0.3"

--- a/learn-hyper/src/main.rs
+++ b/learn-hyper/src/main.rs
@@ -1,10 +1,43 @@
+extern crate futures;
 extern crate hyper;
 extern crate pretty_env_logger;
 #[macro_use] extern crate log;
 
-use hyper::{Body, Server, Request, Response};
+use futures::future;
+use futures::Stream;
+use hyper::{Body, Server, Request, Response, Method, StatusCode};
 use hyper::rt::Future;
-use hyper::service::service_fn_ok;
+use hyper::service::service_fn;
+use hyper::Chunk;
+
+type BoxFut = Box<dyn Future<Item=Response<Body>, Error=hyper::Error> + Send>;
+
+fn routing(req: Request<Body>) -> BoxFut {
+    let mut response: Response<Body> = Response::new(Body::empty());
+
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/") => {
+            *response.body_mut() = Body::from("This is the path root /. Hello, world!!!");
+        },
+        (&Method::POST, "/echo") => {
+            *response.body_mut() = req.into_body();
+        },
+        (&Method::POST, "/echo/uppercase") => {
+            let mapping = req.into_body()
+                            .map(|chunk: Chunk| {
+                                chunk.iter()
+                                    .map(|byte| byte.to_ascii_uppercase())
+                                    .collect::<Vec<u8>>()
+                            });
+            *response.body_mut() = Body::wrap_stream(mapping);
+        },
+        _ => {
+            *response.status_mut() = StatusCode::NOT_FOUND;
+            *response.body_mut() = Body::from("The page is not found.");
+        },
+    };
+    Box::new(future::ok(response))
+}
 
 fn main() {
     pretty_env_logger::init();
@@ -12,13 +45,9 @@ fn main() {
     let addr = ([127, 0, 0, 1], 8088).into();
 
     let server = Server::bind(&addr)
-        .serve(|| {
-            service_fn_ok(move |_: Request<Body>| {
-                Response::new(Body::from("Hello, world!!!"))
-            })
-        })
+        .serve(|| service_fn(routing))
         .map_err(|e| eprintln!("server error {}", e));
 
+    info!("The Server is running now.");
     hyper::rt::run(server);
-    info!("The Server is running now.")
 }

--- a/learn-hyper/src/main.rs
+++ b/learn-hyper/src/main.rs
@@ -3,7 +3,7 @@ extern crate pretty_env_logger;
 #[macro_use] extern crate log;
 
 use hyper::{Body, Server, Request, Response};
-use hyper::rt::{self, Future};
+use hyper::rt::Future;
 use hyper::service::service_fn_ok;
 
 fn main() {
@@ -19,6 +19,6 @@ fn main() {
         })
         .map_err(|e| eprintln!("server error {}", e));
 
-    rt::run(server);
+    hyper::rt::run(server);
     info!("The Server is running now.")
 }


### PR DESCRIPTION
We had added some routing demonstration including `/echo` and `/echo/uppercase`. The former is the simplest case to have request body copied into response body, and the latter returns all bytes after converting them to ASCII uppercase.